### PR TITLE
Update vdm6.json with new API and configuration

### DIFF
--- a/vdm6.json
+++ b/vdm6.json
@@ -1,0 +1,23 @@
+{
+    "api": "5",
+    "type": "anime",
+    "name": "vdm6",
+    "version": "1.0.0",
+    "baseURL": "https://www.vdm6.com/",
+    "searchURL": "https://www.vdm6.com/search_-------------.html?wd=@keyword",
+    "searchList": "//div[1]/div[2]/div/div/div[2]/div//div",
+    "searchName": "//div[2]/div[1]/a",
+    "searchResult": "//div[3]/a[2]",
+    "chapterRoads": "//div[@id='panel1']",
+    "chapterResult": "//div/div//a",
+
+    "muliSources": true,
+    "useWebview": true,
+    "useNativePlayer": true,
+    "usePost": false,
+    "useLegacyParser": false,
+    "adBlocker": true,
+  
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+    "referer": "https://ffzyplayer.com/",
+}

--- a/vdm6.json
+++ b/vdm6.json
@@ -10,14 +10,12 @@
     "searchResult": "//div[3]/a[2]",
     "chapterRoads": "//div[@id='panel1']",
     "chapterResult": "//div/div//a",
-
     "muliSources": true,
     "useWebview": true,
     "useNativePlayer": true,
     "usePost": false,
     "useLegacyParser": false,
     "adBlocker": true,
-  
-    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-    "referer": "https://ffzyplayer.com/",
+    "userAgent": "",
+    "referer": "https://ffzyplayer.com/"
 }


### PR DESCRIPTION
测试可用
部分新番需要手动检索(网站命名规则不一致, 比如不带空格)


部分测试截屏
<img width="1487" height="1382" alt="image" src="https://github.com/user-attachments/assets/eeb48177-de91-4e36-9757-8f884d587f9a" />
<img width="1821" height="1480" alt="image" src="https://github.com/user-attachments/assets/33f9f836-b0cf-40b6-bac2-c648275b3f3f" />

手动检索测试
<img width="1472" height="1165" alt="image" src="https://github.com/user-attachments/assets/f6ccbfa7-1074-470e-998b-6631e93761ba" />

<img width="1473" height="796" alt="image" src="https://github.com/user-attachments/assets/ebc5ab58-0609-48ac-b03a-0690bd171867" />
<img width="1400" height="835" alt="image" src="https://github.com/user-attachments/assets/3b7a6190-1378-494a-bbb3-7a69cd70046b" />
