### PR TITLE
Add initial yinhuadm.one configuration file

### DIFF
--- a/yinhuadm.one.json
+++ b/yinhuadm.one.json
@@ -1,0 +1,33 @@
+{
+  "api": "8",
+  "type": "anime",
+  "name": "yinhuadm.one",//线路发布页，可以自己更新baseUrl
+  "version": "0.1",
+  "muliSources": true,
+  "useWebview": true,
+  "useNativePlayer": true,
+  "usePost": false,
+  "useLegacyParser": false,
+  "adBlocker": false,
+  "userAgent": "",
+  "baseURL": "https://www.yinhuadm.cc/",
+  "searchURL": "https://www.yinhuadm.cc/vch/@keyword",
+  "searchList": "//div[1]/div[3]/div/div/div[2]/div/div",
+  "searchName": "/div[2]/div[1]/a/strong",
+  "searchResult": "/div[3]/a[2]",
+  "chapterRoads": "//div[1]/div[3]/div/div[3]/div",
+  "chapterResult": "/div/div/a",
+  "referer": "",
+  "searchMode": "xpath",
+  "chapterMode": "xpath",
+  "antiCrawlerConfig": {
+    "enabled": false,
+    "captchaType": 1,
+    "captchaImage": "",
+    "captchaInput": "",
+    "captchaButton": "",
+    "captchaDetectType": 1,
+    "captchaDetectValue": "",
+    "captchaScript": ""
+  }
+}


### PR DESCRIPTION
Initial configuration for yinhuadm.one including API version, type, and various settings.
<img width="1140" height="823" alt="image" src="https://github.com/user-attachments/assets/ac9c5fe6-26e6-4bb8-8d54-a72d80f8319b" />
<img width="1690" height="1197" alt="image" src="https://github.com/user-attachments/assets/8ba0210e-bfff-4a64-a2f1-11fb14a126a7" />
