### PR TITLE
feat(rule): add E站弹幕网 (ezdmw)

### DIFF
--- a/ezdmw.json
+++ b/ezdmw.json
@@ -1,0 +1,26 @@
+{
+    "api": "8",
+    "type": "anime",
+    "name": "ezdm",
+    "version": "1.0",
+    "muliSources": true,
+    "useWebview": true,
+    "useNativePlayer": true,
+    "usePost": false,
+    "useLegacyParser": false,
+    "adBlocker": false,
+    "userAgent": "",
+    "baseURL": "https://m.ezdmw.org/",
+    "searchURL": "https://m.ezdmw.org/Index/search.html?searchText=@keyword",
+    "searchList": "//section[@id='some_drama']/div",
+    "searchName": "//p",
+    "searchResult": "//a",
+    "chapterRoads": "//section[@class='anthology'][1]",
+    "chapterResult": "//a[contains(@class,'circuit_switch') and not(contains(@class,'circuit_switch2'))]",
+    "referer": "https://m.ezdmw.org/",
+    "searchMode": "xpath",
+    "chapterMode": "xpath",
+    "antiCrawlerConfig": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
添加 E站弹幕网 规则。

规则的搜索、详情和播放解析已验证正常。

该规则目前也可以用于复现一类非标准 HLS 播放兼容性问题：
部分播放地址返回使用非标准扩展名的 HLS playlist，并带有图片伪装分片。

先以 Draft 提交，方便播放器侧修改测试。

相关 Linux 播放器修改：Predidit/libmpv-linux-build#10